### PR TITLE
Cleanup and fixes for osx

### DIFF
--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -24,6 +24,7 @@ bleno.on('mtuChange', function(mtu) {
   currentMTU = mtu;
 });
 
+// mtu change comes during middle of read and we resets index mid read, what was this trying to do?
 bleno.on('accept', function(){
   queueOffset = 0;
 });

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -16,20 +16,9 @@
 var bleno = require('bleno');
 var util = require('util');
 
-var currentMTU = 0;
-var queueOffset = 0;
-
-bleno.on('mtuChange', function(mtu) {
-  //console.log('on -> mtuChange: ' + mtu);
-  currentMTU = mtu;
-});
-
-// mtu change comes during middle of read and we resets index mid read, what was this trying to do?
-bleno.on('accept', function(){
-  queueOffset = 0;
-});
-
 function HTMLCharacteristic(html) {
+  this._currentMTU = 0;
+  this._queueOffset = 0;
   this._html = html;
   this._buffer = new Buffer(this._html, 'utf8');
   bleno.Characteristic.call(this, {
@@ -42,21 +31,29 @@ function HTMLCharacteristic(html) {
       })
     ]
   });
+
+  var self = this;
+  bleno.on('mtuChange', function(mtu) {
+    self._currentMTU = mtu;
+  });
+
+  bleno.on('disconnect', function(){
+    self._queueOffset = 0;
+  });
 }
 
 util.inherits(HTMLCharacteristic,bleno.Characteristic);
 
 HTMLCharacteristic.prototype.onReadRequest = function(offset, callback) {
-  //var buf = new Buffer(this._html, 'utf8');
-  if (queueOffset < this._buffer.length) {
-    var transfer = currentMTU - 5;
-    var end = queueOffset + transfer >= this._buffer.length ? this._buffer.length: queueOffset + transfer;
-    var slice = this._buffer.slice(queueOffset, end);
+  if (this._queueOffset < this._buffer.length) {
+    var transfer = this._currentMTU - 5;
+    var end = this._queueOffset + transfer >= this._buffer.length ? this._buffer.length: this._queueOffset + transfer;
+    var slice = this._buffer.slice(this._queueOffset, end);
     callback(this.RESULT_SUCCESS, slice);
-    queueOffset = end;
-  } else if (queueOffset === this._buffer.length) {
+    this._queueOffset = end;
+  } else if (this._queueOffset === this._buffer.length) {
     callback(this.RESULT_SUCCESS, new Buffer());
-    queueOffset++;
+    this._queueOffset++;
   }
 
 }

--- a/lib/HTMLCharacteristic.js
+++ b/lib/HTMLCharacteristic.js
@@ -32,14 +32,13 @@ function HTMLCharacteristic(html) {
     ]
   });
 
-  var self = this;
   bleno.on('mtuChange', function(mtu) {
-    self._currentMTU = mtu;
-  });
+    this._currentMTU = mtu;
+  }.bind(this));
 
   bleno.on('disconnect', function(){
-    self._queueOffset = 0;
-  });
+    this._queueOffset = 0;
+  }.bind(this));
 }
 
 util.inherits(HTMLCharacteristic,bleno.Characteristic);

--- a/lib/beacon.js
+++ b/lib/beacon.js
@@ -64,7 +64,13 @@ Beacon.prototype.advertiseFatBeacon = function(title, options) {
         services = services.concat(options.services);
     }
 
-    bleno.setServices(services);
+    bleno.once('advertisingStart', function(err) {
+      if (err) {
+        throw err;
+      }
+
+      bleno.setServices(services);
+    });
 
     this._advertisementData = AdvertisementData.makeFatBeaconBuffer(title, this._txPowerLevel);
     this._removeFlagsIfOsX();


### PR DESCRIPTION
I actually dont know how it works at all on osx atm, but it mostly seems to. The mtu starts out as 0 so the first read is the entire buffer, then the second read is indexed in the middle and overflows?..  but I havent been able to refactor yet without breaking it entirely.  I think the mtus need some refactoring upstream anyway

```
3c68746d6c3e0a20203c686561643e0a202020203c7469746c653e46617420426561636f6e2044656d6f3c2f7469746c653e0a202020203c6d65746120636861727365743d275554462d38273e0a202020203c6d657461206e616d653d276465736372697074696f6e2720636f6e74656e743d2746617420426561636f6e2044656d6f272f3e0a20203c2f686561643e0a20203c626f64793e0a202020203c68313e48656c6c6f576f726c643c2f68313e0a202020203c73766720786d6c6e733d22687474703a2f2f7777772e77332e6f72672f323030302f737667222077696474683d2231373122206865696768743d22323032223e3c672066696c6c3d2223334638324334222066696c6c2d72756c653d226576656e6f6464223e3c7061746820643d224d3134312e322038352e3363302d33312d32352d35362d35362d35362d33302e3720302d35352e382032352d35352e38203536203020313720372e382033322e352032302034322e386c31302d3130632d392e382d372e362d31362d31392e342d31362d33322e3720302d32332e322031382e382d34322034322d343220323320302034312e382031382e382034312e3820343220302031332e332d362e322032352d31362033322e386c31302031306331322e322d31302e322032302d32352e362032302d34322e37222f3e3c7061746820643d224d31342038352e334331342034362034362031342038352e332031347337312e332033322037312e332037312e3363302032312e342d392e352034302e362d32342e352035332e376c31302031306331372e362d31352e372032382e362d33382e342032382e362d36332e3720302d34372d33382e322d38352e332d38352e332d38352e334333382e33203020302033382e3220302038352e3363302032352e332031312034382032382e352036332e366c31302d31304332332e3520313236203134203130362e372031342038352e33222f3e3c7061746820643d224d38392e32203230302e33632d3220322d352e3520322d372e3620306c2d33352e382d33352e38632d322d322d322d352e3520302d372e366c33352e382d333663322d3220352e352d3220372e3620306c33352e3820333663322032203220352e34203020372e356c2d33352e382033352e387a222f3e3c2f673e3c2f7376673e0a20203c2f626f64793e200a3c2f
on -> mtuChange: 505
on -> mtuChange: 505

37222f3e3c7061746820643d224d31342038352e334331342034362034362031342038352e332031347337312e332033322037312e332037312e3363302032312e342d392e352034302e362d32342e352035332e376c31302031306331372e362d31352e372032382e362d33382e342032382e362d36332e3720302d34372d33382e322d38352e332d38352e332d38352e334333382e33203020302033382e3220302038352e3363302032352e332031312034382032382e352036332e366c31302d31304332332e3520313236203134203130362e372031342038352e33222f3e3c7061746820643d224d38392e32203230302e33632d3220322d352e3520322d372e3620306c2d33352e382d33352e38632d322d322d322d352e3520302d372e366c33352e382d333663322d3220352e352d3220372e3620306c33352e3820333663322032203220352e34203020372e356c2d33352e382033352e387a222f3e3c2f673e3c2f7376673e0a20203c2f626f64793e200a3c2f68746d6c3e
```
